### PR TITLE
Fix pagination underflow

### DIFF
--- a/web/image.rs
+++ b/web/image.rs
@@ -295,7 +295,13 @@ impl From<ImageQueryParam> for query::ImageQuery {
                 .map(ImageQueryKind::Where)
                 .unwrap_or(ImageQueryKind::All),
             limit: value.limit.or(Some(20)),
-            offset: Some((value.page.unwrap_or(1) - 1) * value.limit.unwrap_or(20)),
+            offset: Some(
+                value
+                    .page
+                    .unwrap_or(1)
+                    .saturating_sub(1)
+                    * value.limit.unwrap_or(20),
+            ),
             order: order_by.or(Some(OrderBy::CreatedAtDesc)),
         }
     }

--- a/web/tag.rs
+++ b/web/tag.rs
@@ -73,7 +73,13 @@ pub async fn get_tags(
             .unwrap_or(TagQueryKind::All),
     )
     .with_limit(params.limit.unwrap_or(20))
-    .with_offset((params.page.unwrap_or(1) - 1) * params.limit.unwrap_or(20));
+    .with_offset(
+        params
+            .page
+            .unwrap_or(1)
+            .saturating_sub(1)
+            * params.limit.unwrap_or(20),
+    );
 
     let tags = query_tags(&app.db, query).await?;
     let tags: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();


### PR DESCRIPTION
## Summary
- fix page offset calculation when `page=0`

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68495e33afa083308ffaa26afdd3bed1