### PR TITLE
Add delete image API endpoint

### DIFF
--- a/web/image.rs
+++ b/web/image.rs
@@ -396,6 +396,17 @@ pub async fn put_tags(
     )))
 }
 
+pub async fn delete_image(
+    State(app): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<StatusCode, ImageError> {
+    let hash = PixelHash::from_signed(id);
+
+    remove_image(&app.storage, &app.db, hash).await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 pub enum ImageError {
     App(AppError),
 

--- a/web/main.rs
+++ b/web/main.rs
@@ -4,8 +4,8 @@ mod tag;
 use axum::extract::{DefaultBodyLimit, Path, State};
 use axum::http::{Response, StatusCode};
 use axum::response::IntoResponse;
-use axum::routing::put;
-use axum::{Router, routing::get};
+use axum::routing::{get, put, delete};
+use axum::Router;
 use buru::{database::Database, storage::Storage};
 use sqlx::Pool;
 use std::{env, fs};
@@ -90,7 +90,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/images", get(image::get_images).post(image::post_image))
-        .route("/images/{id}", get(image::get_image))
+        .route("/images/{id}", get(image::get_image).delete(image::delete_image))
         .route("/images/{id}/tags", put(image::put_tags))
         .route("/tags", get(tag::get_tags))
         .route("/tags/suggest", get(tag::suggest_tags))


### PR DESCRIPTION
## Summary
- enable `DELETE /images/{id}` API route
- implement `delete_image` handler to remove image from storage and database
- update router imports and routing configuration for delete

## Testing
- `cargo check --quiet` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d5e42deb88330825880ac7d11874d